### PR TITLE
HAS-7 Change Triggers for Building on Tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Angular CI
 on:
   push:
+    tags:
+      - "v*"
     branches:
       - '**'
   pull_request:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change adds a trigger for CI runs on tag pushes matching the pattern "v*". 

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR4-R5): Added a trigger for CI runs on tag pushes matching the pattern "v*".